### PR TITLE
Prevent startup crash on mobile

### DIFF
--- a/core/src/braindustry/ui/fragments/ModMenuFragment.java
+++ b/core/src/braindustry/ui/fragments/ModMenuFragment.java
@@ -38,7 +38,8 @@ public class ModMenuFragment {
         Events.on(EventType.DisposeEvent.class, (event) -> {
             lastRenderer.dispose();
         });
-        try {
+        
+        if(!mobile) {
             WidgetGroup widgetGroup = (WidgetGroup) ui.menuGroup.getChildren().first();
             widgetGroup.getChildren().set(0, new Element() {
                 {
@@ -66,8 +67,6 @@ public class ModMenuFragment {
                     drawTitle();
                 }
             });
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
         Runnable update = () -> {
             MenuButtons.menuButton(new MenuButton("@menu.title", Icon.menu,


### PR DESCRIPTION
On mobile, the custom title will not be rendered. This is better than crashing on startup. I have not tested this.

If this is not fixed or merged soon, I will be forced to remove Braindustry from the mod browser; top mods that crash immediately upon startup are a very bad user experience. 

Technical note: Never modify Group children directly, it breaks things. Remove and add children using the Group methods provided instead.