### PR TITLE
Fix Android desugaring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ task jarAndroid {
 
     doLast {
         //collect dependencies needed for desugaring
-        def files = (configurations.compileClasspath.asList() + configurations.runtimeClasspath.asList() + [new File("$sdkRoot/platforms/android-$sdkVersion/android.jar")])
+        def files = (project(":core").configurations.compileClasspath.asList() + project(":core").configurations.runtimeClasspath.asList() + [new File("$sdkRoot/platforms/android-$sdkVersion/android.jar")])
         def dependencies = files.collect { "--classpath $it.path" }.join(" ")
 
         //dex and desugar files - this requires d8 in your PATH


### PR DESCRIPTION
With a Gradle submodule, you're not collecting the dependencies needed for desugaring correctly. This should fix the latest Android crash.